### PR TITLE
Support for .xsf, .xtp, .xcc and the character .xrsc packages, plus texture and road material fixes

### DIFF
--- a/Files/DdsFile.cs
+++ b/Files/DdsFile.cs
@@ -1,0 +1,29 @@
+﻿using CodeX.Core.Engine;
+using CodeX.Core.Utilities;
+using CodeX.Games.MCLA.RPF3;
+
+namespace CodeX.Games.MCLA.Files
+{
+    //Plain DDS files sitting loose in the archive (sky, vehicle/shared_font, ...). They're
+    //standard little endian DDS, not a RAGE resource, so they just need wrapping in a pack.
+    public class DdsFile(Rpf3FileEntry file) : TexturePack(file)
+    {
+        public override void Load(byte[] data)
+        {
+            Textures = [];
+
+            var tex = DDSIO.GetTexture(data);
+            if (tex == null) return;
+
+            tex.Name = System.IO.Path.GetFileNameWithoutExtension(FileInfo?.Name ?? "texture");
+            tex.Sampler = TextureSampler.AnisotropicWrap;
+            tex.FilePack = this;
+            Textures[tex.Name] = tex;
+        }
+
+        public override byte[] Save()
+        {
+            return null;
+        }
+    }
+}

--- a/Files/XccFile.cs
+++ b/Files/XccFile.cs
@@ -1,0 +1,217 @@
+﻿using CodeX.Core.Engine;
+using CodeX.Core.Utilities;
+using System.Numerics;
+using System.Text;
+
+namespace CodeX.Games.MCLA.Files
+{
+    //.xcc - CarConfig. Not an RSC5 resource: CarConfig::Load reads the file straight over the
+    //object (a flat 8176 byte struct) and only patches the vtables back in, so the layout here
+    //is the in-memory class layout. Names come from the game's own "CarConfig" strings.
+    public class XccFile : FilePack
+    {
+        public const int FileSize = 8176;
+
+        //Vinyl layers: 288 slots of 20 bytes, split into five surfaces. The split comes from the
+        //game's own tables - offsets at 0x827E9770 and capacities at 0x820510B0.
+        public const int LayersOffset = 0x0904;
+        public const int LayerSize = 20;
+        public const int LayerSlots = 288;
+        public static readonly int[] SurfaceOffsets = [0, 64, 128, 192, 208];
+        public static readonly int[] SurfaceCapacities = [64, 64, 64, 16, 16];
+
+        public string ConfigName { get; set; }
+        public string VehicleName { get; set; }
+        public uint ConfigId { get; set; } //Differs between configs of the same car
+        public string LicensePlate { get; set; }
+        public byte LicensePlateStyle { get; set; }
+        public int[] PerformanceLevels { get; set; } //Six upgrade categories, 0-5
+        public XccVinylSurface[] Surfaces { get; set; }
+
+        public XccFile()
+        {
+        }
+
+        public XccFile(GameArchiveFileInfo info) : base(info)
+        {
+        }
+
+        public override void Load(byte[] data)
+        {
+            if (data == null || data.Length < FileSize)
+            {
+                LoadException = new Exception($"Not a CarConfig: expected {FileSize} bytes, got {data?.Length ?? 0}");
+                return;
+            }
+
+            VehicleName = ReadString(data, 0x1FAD, 32);
+            ConfigName = ReadString(data, 0x1FCD, 34);
+            ConfigId = ReadUInt32(data, 0x1FA8);
+            LicensePlate = ReadString(data, 0x0847, 7);
+            LicensePlateStyle = data[0x084F];
+
+            PerformanceLevels = new int[6];
+            for (int i = 0; i < PerformanceLevels.Length; i++)
+            {
+                PerformanceLevels[i] = (int)ReadUInt32(data, 0x0680 + i * 0x30);
+            }
+
+            Surfaces = new XccVinylSurface[SurfaceOffsets.Length];
+            for (int s = 0; s < Surfaces.Length; s++)
+            {
+                Surfaces[s] = new XccVinylSurface(s, SurfaceOffsets[s], SurfaceCapacities[s], data);
+            }
+        }
+
+        public override byte[] Save()
+        {
+            return null;
+        }
+
+        public override void Read(MetaNodeReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(MetaNodeWriter writer)
+        {
+            writer.WriteString("ConfigName", ConfigName);
+            writer.WriteString("VehicleName", VehicleName);
+            writer.WriteUInt32("ConfigId", ConfigId);
+            writer.WriteString("LicensePlate", LicensePlate);
+            writer.WriteByte("LicensePlateStyle", LicensePlateStyle);
+            writer.WriteInt32Array("PerformanceLevels", PerformanceLevels);
+            writer.WriteNodeArray("Surfaces", Surfaces);
+        }
+
+        internal static string ReadString(byte[] data, int offset, int length)
+        {
+            var sb = new StringBuilder(length);
+            for (int i = 0; i < length; i++)
+            {
+                var b = data[offset + i];
+                if (b == 0 || b == 0xCD) break;
+                sb.Append((char)b);
+            }
+            return sb.ToString();
+        }
+
+        internal static uint ReadUInt32(byte[] data, int offset)
+        {
+            return (uint)((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]);
+        }
+
+        internal static ushort ReadUInt16(byte[] data, int offset)
+        {
+            return (ushort)((data[offset] << 8) | data[offset + 1]);
+        }
+
+        //Scale, position and rotation are stored as halfs
+        internal static float ReadHalf(byte[] data, int offset)
+        {
+            return (float)BitConverter.UInt16BitsToHalf(ReadUInt16(data, offset));
+        }
+    }
+
+    public class XccVinylSurface : MetaNode
+    {
+        public int Index { get; set; }
+        public int FirstSlot { get; set; }
+        public int Capacity { get; set; }
+        public XccVinylLayer[] Layers { get; set; }
+
+        public XccVinylSurface()
+        {
+        }
+
+        public XccVinylSurface(int index, int firstSlot, int capacity, byte[] data)
+        {
+            Index = index;
+            FirstSlot = firstSlot;
+            Capacity = capacity;
+
+            //The game compacts layers towards the start of the surface, so the first empty slot
+            //ends the list (see the shuffle in sub_82393220).
+            var layers = new List<XccVinylLayer>();
+            for (int i = 0; i < capacity; i++)
+            {
+                var offset = XccFile.LayersOffset + (firstSlot + i) * XccFile.LayerSize;
+                var layer = new XccVinylLayer(i, data, offset);
+                if (layer.ShapeId == 0xFFFF) break;
+                layers.Add(layer);
+            }
+            Layers = [.. layers];
+        }
+
+        public void Read(MetaNodeReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write(MetaNodeWriter writer)
+        {
+            writer.WriteInt32("Index", Index);
+            writer.WriteInt32("FirstSlot", FirstSlot);
+            writer.WriteInt32("Capacity", Capacity);
+            writer.WriteNodeArray("Layers", Layers);
+        }
+
+        public override string ToString()
+        {
+            return $"Surface {Index}: {Layers?.Length ?? 0}/{Capacity} layers";
+        }
+    }
+
+    public class XccVinylLayer : MetaNode
+    {
+        public int Index { get; set; }
+        public ushort ShapeId { get; set; } //0xFFFF = empty slot. Decimal coded as group * 1000 + shape
+        public uint ColourArgb { get; set; }
+        public Vector2 Scale { get; set; }
+        public Vector2 Position { get; set; }
+        public float Rotation { get; set; }
+        public ushort Unknown_Ch { get; set; }
+        public byte Unknown_12h { get; set; }
+        public byte Unknown_13h { get; set; }
+
+        public XccVinylLayer()
+        {
+        }
+
+        public XccVinylLayer(int index, byte[] data, int offset)
+        {
+            Index = index;
+            Scale = new Vector2(XccFile.ReadHalf(data, offset), XccFile.ReadHalf(data, offset + 2));
+            Position = new Vector2(XccFile.ReadHalf(data, offset + 4), XccFile.ReadHalf(data, offset + 6));
+            ColourArgb = XccFile.ReadUInt32(data, offset + 8);
+            Unknown_Ch = XccFile.ReadUInt16(data, offset + 12);
+            Rotation = XccFile.ReadHalf(data, offset + 14);
+            ShapeId = XccFile.ReadUInt16(data, offset + 16);
+            Unknown_12h = data[offset + 18];
+            Unknown_13h = data[offset + 19];
+        }
+
+        public void Read(MetaNodeReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write(MetaNodeWriter writer)
+        {
+            writer.WriteInt32("Index", Index);
+            writer.WriteUInt16("ShapeId", ShapeId);
+            writer.WriteString("Colour", $"0x{ColourArgb:X8}"); //ARGB
+            writer.WriteVector2("Scale", Scale);
+            writer.WriteVector2("Position", Position);
+            writer.WriteSingle("Rotation", Rotation);
+            writer.WriteUInt16("Unknown_Ch", Unknown_Ch);
+            writer.WriteByte("Unknown_12h", Unknown_12h);
+            writer.WriteByte("Unknown_13h", Unknown_13h);
+        }
+
+        public override string ToString()
+        {
+            return $"Layer {Index}: shape {ShapeId}";
+        }
+    }
+}

--- a/Files/XrscFile.cs
+++ b/Files/XrscFile.cs
@@ -1,4 +1,5 @@
-﻿using CodeX.Core.Engine;
+﻿using CodeX.Core.Utilities;
+using CodeX.Core.Engine;
 using CodeX.Games.MCLA.RPF3;
 using CodeX.Games.MCLA.RSC5;
 
@@ -16,10 +17,23 @@ namespace CodeX.Games.MCLA.Files
             Fragment = r.ReadBlock<Rsc5ModelResource>();
             Pieces = [];
 
-            if (Fragment != null)
+            //A "_set" package holds a whole wardrobe of drawables, everything else holds one
+            var drawables = Fragment?.Drawables;
+            if (drawables != null && drawables.Length > 0)
             {
-                var drawable = Fragment.Drawable.Item;
+                foreach (var drawable in drawables)
+                {
+                    drawable.FilePack = this;
+                    drawable.Name ??= e.Name;
+                    Pieces[JenkHash.GenHash(drawable.Name)] = drawable;
+                }
+                Piece = drawables[0];
+            }
+            else if (Fragment?.Drawable != null)
+            {
+                var drawable = Fragment.Drawable;
                 drawable.FilePack = this;
+                drawable.Name ??= e.Name;
 
                 Piece = drawable;
                 Pieces.Add(e.ShortNameHash, drawable);

--- a/Files/XsfFile.cs
+++ b/Files/XsfFile.cs
@@ -1,0 +1,90 @@
+﻿using CodeX.Core.Engine;
+using CodeX.Core.Utilities;
+using CodeX.Games.MCLA.RPF3;
+using CodeX.Games.MCLA.RSC5;
+
+namespace CodeX.Games.MCLA.Files
+{
+    //.xsf, the serialized Flash movie used for every piece of UI (hud, pause, garage...).
+    //It is not a texture dictionary - the art is spread over the bitmap and font characters,
+    //so the pack is built by walking the character table and sweeping for the leftover atlases.
+    public class XsfFile(Rpf3FileEntry file) : TexturePack(file)
+    {
+        public Rpf3FileEntry Entry = file;
+        public Rsc5FlashMovie Movie { get; private set; }
+        public List<string> ExternalTextures { get; } = [];
+
+        public override void Load(byte[] data)
+        {
+            var e = FileInfo as Rpf3ResourceFileEntry;
+            var r = new Rsc5DataReader(e, data, DataEndianess.BigEndian);
+
+            Movie = r.ReadBlock<Rsc5FlashMovie>();
+            Textures = [];
+
+            var characters = Movie?.Characters;
+            if (characters != null)
+            {
+                foreach (var character in characters)
+                {
+                    if (character == null) continue;
+                    if (character.ObjectType != Rsc5FlashObjectType.Bitmap) continue;
+
+                    if (character.Texture != null)
+                    {
+                        AddTexture(character.Texture);
+                    }
+                    else if (!string.IsNullOrEmpty(character.ExternalTextureName))
+                    {
+                        ExternalTextures.Add(character.ExternalTextureName);
+                    }
+                }
+            }
+
+            //Fonts reach their glyph atlas through structures that aren't decoded yet, so anything
+            //the character walk missed is picked up by sweeping the virtual segment.
+            foreach (var position in Rsc5Flash.FindTextureBlocks(data, r.VirtualSize))
+            {
+                try
+                {
+                    var tex = r.ReadBlock<Rsc5Texture>(position);
+                    if (tex != null)
+                    {
+                        AddTexture(tex);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private void AddTexture(Rsc5Texture tex)
+        {
+            if (tex.Data == null) return;
+
+            tex.Name = GetShortName(tex.Name);
+            tex.FilePack = this;
+
+            var name = tex.Name;
+            for (int i = 1; Textures.TryGetValue(name, out var existing) && existing != tex; i++)
+            {
+                name = tex.Name + "#" + i;
+            }
+            Textures[name] = tex;
+        }
+
+        //Names are authoring paths, eg "t:/mc4/assets/ui/hud/textures/hud_0327"
+        private static string GetShortName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return "texture";
+            var slash = name.LastIndexOfAny(['/', '\\']);
+            return (slash >= 0) ? name[(slash + 1)..] : name;
+        }
+
+        public override byte[] Save()
+        {
+            return null;
+        }
+    }
+}

--- a/Files/XtdFile.cs
+++ b/Files/XtdFile.cs
@@ -4,7 +4,7 @@ using CodeX.Games.MCLA.RSC5;
 
 namespace CodeX.Games.MCLA.Files
 {
-    class XtdFile(Rpf3FileEntry file) : TexturePack(file)
+    public class XtdFile(Rpf3FileEntry file) : TexturePack(file)
     {
         public Rsc5TextureDictionary TextureDictionary = null;
 

--- a/Files/XtlFile.cs
+++ b/Files/XtlFile.cs
@@ -4,7 +4,10 @@ using CodeX.Games.MCLA.RSC5;
 
 namespace CodeX.Games.MCLA.Files
 {
-    class XtlFile(Rpf3FileEntry file) : TexturePack(file)
+    //.xtl and .xtp, both resource type 83. The damage/zone/scratch maps hang off the root, and
+    //anything else the package carries (brake rotors, calipers, wheels) lives in the shader
+    //group's own texture dictionary.
+    public class XtlFile(Rpf3FileEntry file) : TexturePack(file)
     {
         public Rsc5XtlTextureDictionary Taillights = null;
 
@@ -16,23 +19,38 @@ namespace CodeX.Games.MCLA.Files
             Taillights = r.ReadBlock<Rsc5XtlTextureDictionary>();
             Textures = [];
 
-            if (Taillights != null)
+            if (Taillights == null)
             {
-                var texs = new[]
-                {
-                    Taillights.ZoneTexture.Item,
-                    Taillights.MaxDamageTexture.Item,
-                    Taillights.ScratchTexture.Item
-                };
+                return;
+            }
 
-                foreach (var tex in texs)
+            var texs = new[]
+            {
+                Taillights.ZoneTexture.Item,
+                Taillights.MaxDamageTexture.Item,
+                Taillights.ScratchTexture.Item
+            };
+
+            foreach (var tex in texs)
+            {
+                Add(tex);
+            }
+
+            var dict = Taillights.ShaderGroup.Item?.TextureDictionary.Item;
+            if (dict?.Textures.Items != null)
+            {
+                foreach (var tex in dict.Textures.Items)
                 {
-                    if (tex != null)
-                    {
-                        Textures[tex.Name] = tex;
-                    }
+                    Add(tex);
                 }
             }
+        }
+
+        private void Add(Rsc5Texture tex)
+        {
+            if (tex?.Name == null || tex.Data == null) return;
+            tex.FilePack = this;
+            Textures[tex.Name] = tex;
         }
 
         public override byte[] Save()

--- a/RPF3/Rpf3Crypto.cs
+++ b/RPF3/Rpf3Crypto.cs
@@ -705,25 +705,53 @@ namespace CodeX.Games.MCLA.RPF3
             return size;
         }
 
-        public static byte[] UnswizzleXbox360Data(byte[] data, int width, int height, TextureFormat format)
+        public const int TextureTileBlocks = 32; //A Xenos tile is 32x32 blocks
+
+        public static bool GetBlockLayout(TextureFormat format, out int blockSizeRow, out int texelPitch)
         {
-            int texelPitch, blockSizeRow;
             switch (format)
             {
-                case TextureFormat.L8:
-                case TextureFormat.A8R8G8B8:
-                    return data;
                 case TextureFormat.BC1:
                     blockSizeRow = 4;
                     texelPitch = 8;
-                    break;
+                    return true;
                 case TextureFormat.BC2:
                 case TextureFormat.BC3:
                     blockSizeRow = 4;
                     texelPitch = 16;
-                    break;
+                    return true;
                 default:
-                    throw new NotImplementedException("Unsupported format for compression");
+                    blockSizeRow = 0;
+                    texelPitch = 0;
+                    return false;
+            }
+        }
+
+        //Blocks along one axis, padded out to whole tiles
+        public static int GetTiledBlocks(int texels, int blockSizeRow)
+        {
+            var blocks = (texels + blockSizeRow - 1) / blockSizeRow;
+            return (blocks + TextureTileBlocks - 1) / TextureTileBlocks * TextureTileBlocks;
+        }
+
+        //A tiled surface pads both its row pitch and its row count out to whole tiles, so a
+        //512x180 DXT5 occupies 128x64 blocks (0x20000 bytes), not 128x45. Sizing the read from
+        //the texel dimensions alone reads too little and then untiles past the end of it.
+        public static int GetTiledSurfaceSize(int width, int height, TextureFormat format)
+        {
+            if (!GetBlockLayout(format, out var blockSizeRow, out var texelPitch))
+            {
+                return width * height * (format == TextureFormat.A8R8G8B8 ? 4 : 1);
+            }
+            return GetTiledBlocks(width, blockSizeRow) * GetTiledBlocks(height, blockSizeRow) * texelPitch;
+        }
+
+        public static byte[] UnswizzleXbox360Data(byte[] data, int width, int height, TextureFormat format)
+        {
+            if (!GetBlockLayout(format, out var blockSizeRow, out var texelPitch))
+            {
+                if (format is TextureFormat.L8 or TextureFormat.A8R8G8B8) return data;
+                throw new NotImplementedException("Unsupported format for compression");
             }
 
             //Reverse every two bytes in the texture data
@@ -735,12 +763,10 @@ namespace CodeX.Games.MCLA.RPF3
                 }
             }
 
-            //Calculate virtual block dimensions
-            var virtualWidth = GetVirtualSize(width);
-            var virtualHeight = GetVirtualSize(height);
-            var virtualBlockWidth = virtualWidth / blockSizeRow;
-            var virtualBlockHeight = virtualHeight / blockSizeRow;
-            var unswizzledBuffer = new byte[data.Length];
+            //Tile aligned block dimensions - the layout the data is actually stored in
+            var virtualBlockWidth = GetTiledBlocks(width, blockSizeRow);
+            var virtualBlockHeight = GetTiledBlocks(height, blockSizeRow);
+            var unswizzledBuffer = new byte[virtualBlockWidth * virtualBlockHeight * texelPitch];
 
             //Perform unswizzling
             for (int j = 0; j < virtualBlockHeight; j++)
@@ -753,28 +779,30 @@ namespace CodeX.Games.MCLA.RPF3
 
                     var srcOffset = j * virtualBlockWidth * texelPitch + i * texelPitch; //Source offset from the swizzled texture data
                     var destOffset = y * virtualBlockWidth * texelPitch + x * texelPitch; //Destination offset in the unswizzled buffer
+
+                    //The last texture of a segment can be stored short of its padded size
+                    if (srcOffset + texelPitch > data.Length) continue;
+                    if (destOffset < 0 || destOffset + texelPitch > unswizzledBuffer.Length) continue;
                     Array.Copy(data, srcOffset, unswizzledBuffer, destOffset, texelPitch);
                 }
             }
 
-            //If the texture uses virtual dimensions, remove the extra padding
-            if (width < 128 || height < 128)
+            //Drop the tile padding to get back to the real dimensions
+            var actualBlockWidth = (width + blockSizeRow - 1) / blockSizeRow;
+            var actualBlockHeight = (height + blockSizeRow - 1) / blockSizeRow;
+            if (actualBlockWidth == virtualBlockWidth && actualBlockHeight == virtualBlockHeight)
             {
-                //Fit the texture to the actual dimensions (width, height)
-                var actualBlockWidth = width / blockSizeRow;
-                var actualBlockHeight = height / blockSizeRow;
-                var trimmedBuffer = new byte[actualBlockWidth * actualBlockHeight * texelPitch];
-
-                //Copy the relevant part of the unswizzled buffer into a trimmed buffer
-                for (int j = 0; j < actualBlockHeight; j++)
-                {
-                    var srcOffset = j * virtualBlockWidth * texelPitch;
-                    var destOffset = j * actualBlockWidth * texelPitch;
-                    Array.Copy(unswizzledBuffer, srcOffset, trimmedBuffer, destOffset, actualBlockWidth * texelPitch);
-                }
-                unswizzledBuffer = trimmedBuffer;
+                return unswizzledBuffer;
             }
-            return unswizzledBuffer;
+
+            var trimmedBuffer = new byte[actualBlockWidth * actualBlockHeight * texelPitch];
+            for (int j = 0; j < actualBlockHeight; j++)
+            {
+                var srcOffset = j * virtualBlockWidth * texelPitch;
+                var destOffset = j * actualBlockWidth * texelPitch;
+                Array.Copy(unswizzledBuffer, srcOffset, trimmedBuffer, destOffset, actualBlockWidth * texelPitch);
+            }
+            return trimmedBuffer;
         }
 
         //Translates a linear texture memory offset to a 2D tiled X address

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -67,6 +67,7 @@ namespace CodeX.Games.MCLA.RPF3
             InitFileType(".xtl", "Damage Textures", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xspm", "Streaming Pack Map", FileTypeIcon.File);
             InitFileType(".xct", "City File/ Car Tuning", FileTypeIcon.File);
+            InitFileType(".dds", "DirectDraw Surface", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xcs", "City Sector", FileTypeIcon.Piece, FileTypeAction.ViewModels);
             InitFileType(".xapk", "Animation Pack", FileTypeIcon.File);
             InitFileType(".xov", "Overlay", FileTypeIcon.File);
@@ -363,7 +364,13 @@ namespace CodeX.Games.MCLA.RPF3
             if (file is not Rpf3FileEntry entry)
                 return null;
 
-            if (file.NameLower.EndsWith(".xsf"))
+            if (file.NameLower.EndsWith(".dds"))
+            {
+                var dds = new DdsFile(entry);
+                dds.Load(data);
+                return dds;
+            }
+            else if (file.NameLower.EndsWith(".xsf"))
             {
                 var xsf = new XsfFile(entry);
                 xsf.Load(data);

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -67,6 +67,7 @@ namespace CodeX.Games.MCLA.RPF3
             InitFileType(".xtl", "Damage Textures", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xspm", "Streaming Pack Map", FileTypeIcon.File);
             InitFileType(".xct", "City File/ Car Tuning", FileTypeIcon.File);
+            InitFileType(".xcc", "Car Config", FileTypeIcon.XmlFile, FileTypeAction.ViewXml);
             InitFileType(".dds", "DirectDraw Surface", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xcs", "City Sector", FileTypeIcon.Piece, FileTypeAction.ViewModels);
             InitFileType(".xapk", "Animation Pack", FileTypeIcon.File);
@@ -309,6 +310,8 @@ namespace CodeX.Games.MCLA.RPF3
                 case ".meta":
                     newfilename = file.Name;
                     return TextUtil.GetUTF8Text(data);
+                case ".xcc":
+                    return ConvertToXml<XccFile>(file, data, out newfilename, "MCLACarConfig");
             }
 
             newfilename = file.Name + ".xml";

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -63,7 +63,7 @@ namespace CodeX.Games.MCLA.RPF3
             InitFileType(".xshp", "Car Vinyl Shape", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xsf", "Flash UI", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xrsc", "Model Resource", FileTypeIcon.Piece, FileTypeAction.ViewModels);
-            InitFileType(".xtp", "Vehicle Top Part", FileTypeIcon.File);
+            InitFileType(".xtp", "Vehicle Part Textures", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xtl", "Damage Textures", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xspm", "Streaming Pack Map", FileTypeIcon.File);
             InitFileType(".xct", "City File/ Car Tuning", FileTypeIcon.File);
@@ -375,7 +375,7 @@ namespace CodeX.Games.MCLA.RPF3
                 xtd.Load(data);
                 return xtd;
             }
-            else if (file.NameLower.EndsWith(".xtl"))
+            else if (file.NameLower.EndsWith(".xtl") || file.NameLower.EndsWith(".xtp"))
             {
                 var xtl = new XtlFile(entry);
                 xtl.Load(data);

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -61,7 +61,7 @@ namespace CodeX.Games.MCLA.RPF3
             InitFileType(".xpfl", "Particle Effects Library", FileTypeIcon.Animation);
             InitFileType(".xsd", "XSD File", FileTypeIcon.Library, FileTypeAction.ViewXml);
             InitFileType(".xshp", "Car Vinyl Shape", FileTypeIcon.Image, FileTypeAction.ViewTextures);
-            InitFileType(".xsf", "Flash UI", FileTypeIcon.Image);
+            InitFileType(".xsf", "Flash UI", FileTypeIcon.Image, FileTypeAction.ViewTextures);
             InitFileType(".xrsc", "Model Resource", FileTypeIcon.Piece, FileTypeAction.ViewModels);
             InitFileType(".xtp", "Vehicle Top Part", FileTypeIcon.File);
             InitFileType(".xtl", "Damage Textures", FileTypeIcon.Image, FileTypeAction.ViewTextures);
@@ -363,7 +363,13 @@ namespace CodeX.Games.MCLA.RPF3
             if (file is not Rpf3FileEntry entry)
                 return null;
 
-            if (file.NameLower.EndsWith(".xtd"))
+            if (file.NameLower.EndsWith(".xsf"))
+            {
+                var xsf = new XsfFile(entry);
+                xsf.Load(data);
+                return xsf;
+            }
+            else if (file.NameLower.EndsWith(".xtd"))
             {
                 var xtd = new XtdFile(entry);
                 xtd.Load(data);

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -94,6 +94,11 @@ namespace CodeX.Games.MCLA.RPF3
             InitFileType(".grid", "GRID File", FileTypeIcon.TextFile, FileTypeAction.ViewText);
             InitFileType(".aogrid", "AOGRID File", FileTypeIcon.TextFile, FileTypeAction.ViewText);
             InitFileType(".career", "CAREER File", FileTypeIcon.TextFile, FileTypeAction.ViewText);
+            InitFileType(".sharetex", "Shared Texture List", FileTypeIcon.XmlFile, FileTypeAction.ViewXml);
+            InitFileType(".mcpowerup", "Powerup Definition", FileTypeIcon.TextFile, FileTypeAction.ViewText);
+            InitFileType(".dcl", "Shader Declaration", FileTypeIcon.TextFile, FileTypeAction.ViewText);
+            InitFileType(".skel", "Skeleton Definition", FileTypeIcon.TextFile, FileTypeAction.ViewText);
+            InitFileType(".odr", "Drawable Definition", FileTypeIcon.TextFile, FileTypeAction.ViewText);
         }
 
         public override void InitCreateInfos()

--- a/RPF3/Rpf3FileManager.cs
+++ b/RPF3/Rpf3FileManager.cs
@@ -521,6 +521,13 @@ namespace CodeX.Games.MCLA.RPF3
                             }
                         }
                     }
+
+                    //A road material only gets its albedo once the control and decal maps have
+                    //resolved, which happens here rather than back when the shader was set up
+                    if (geom.RoadMaterial && slots.Length > 2)
+                    {
+                        slots[0] = Rsc5RoadMaterial.GetAlbedo(slots[1], slots[2]);
+                    }
                 }
             }
         }

--- a/RSC5/Rsc5Data.cs
+++ b/RSC5/Rsc5Data.cs
@@ -57,6 +57,23 @@ namespace CodeX.Games.MCLA.RSC5
             return dst;
         }
 
+        //The padded size of the last texture in a segment can run past the end of the data.
+        //Reading it as far as the data goes and zero filling the rest keeps the caller's size
+        //assumptions intact instead of throwing.
+        public byte[] ReadBytesPadded(int count)
+        {
+            int dataOffset = GetDataOffset();
+            var dst = new byte[count];
+            var available = Math.Min(count, Data.Length - dataOffset);
+
+            if (available > 0)
+            {
+                Buffer.BlockCopy(Data, dataOffset, dst, 0, available);
+            }
+            Position += (ulong)count;
+            return dst;
+        }
+
         public new byte[] ReadBytesReversed(int count)
         {
             var numArray = ReadBytes(count);

--- a/RSC5/Rsc5Drawable.cs
+++ b/RSC5/Rsc5Drawable.cs
@@ -1941,15 +1941,26 @@ namespace CodeX.Games.MCLA.RSC5
         }
     }
 
-    [TC(typeof(EXP))] public class Rsc5ShaderGroup : Rsc5BlockBaseMap
+    [TC(typeof(EXP))] public class Rsc5ShaderGroup : Rsc5FileBase
     {
         public override ulong BlockLength => 16;
         public override uint VFT { get; set; } = 0x005AA6FC;
+        public Rsc5Ptr<Rsc5TextureDictionary> TextureDictionary { get; set; } //Sits where pgBase keeps its block map; only packages that embed their own textures fill it in
         public Rsc5PtrArr<Rsc5Shader> Shaders { get; set; }
 
         public override void Read(Rsc5DataReader reader)
         {
             base.Read(reader);
+
+            var position = reader.Position;
+            var pointer = reader.ReadUInt32();
+            if (IsTextureDictionary(reader, pointer))
+            {
+                reader.Position = position;
+                TextureDictionary = reader.ReadPtr<Rsc5TextureDictionary>();
+                reader.Position = position + 4;
+            }
+
             Shaders = reader.ReadPtrArr<Rsc5Shader>();
 
             if (Shaders.Items != null)
@@ -1966,6 +1977,30 @@ namespace CodeX.Games.MCLA.RSC5
                     }
                 }
             }
+        }
+
+        //The slot holds a plain block map in most files, so it's only followed when the target
+        //really looks like a grcTextureDictionary: null block map, and matching hash and texture
+        //arrays with the same non-zero count.
+        private static bool IsTextureDictionary(Rsc5DataReader reader, uint pointer)
+        {
+            if ((pointer & 0xF0000000) != Rpf3Crypto.VIRTUAL_BASE) return false;
+
+            var data = reader.Data;
+            var offset = (int)(pointer & 0x0FFFFFFF);
+            if (offset < 0 || offset + 32 > Math.Min(reader.VirtualSize, data.Length)) return false;
+
+            static uint U32(byte[] d, int o) => (uint)((d[o] << 24) | (d[o + 1] << 16) | (d[o + 2] << 8) | d[o + 3]);
+            static ushort U16(byte[] d, int o) => (ushort)((d[o] << 8) | d[o + 1]);
+
+            if (U32(data, offset + 4) != 0) return false; //block map
+            var hashes = U32(data, offset + 0x10);
+            var textures = U32(data, offset + 0x18);
+            if ((hashes & 0xF0000000) != Rpf3Crypto.VIRTUAL_BASE) return false;
+            if ((textures & 0xF0000000) != Rpf3Crypto.VIRTUAL_BASE) return false;
+
+            var count = U16(data, offset + 0x14);
+            return count != 0 && count == U16(data, offset + 0x1C);
         }
 
         public override void Write(Rsc5DataWriter writer)

--- a/RSC5/Rsc5Drawable.cs
+++ b/RSC5/Rsc5Drawable.cs
@@ -925,6 +925,11 @@ namespace CodeX.Games.MCLA.RSC5
                         break;
                 }
 
+                //The alpha channel of an MCLA diffuse map is a specular/gloss mask, not opacity -
+                //only shaders that declare a non-solid draw bucket really blend. Handing the mask
+                //to the core shader punches holes through skin, beards and car bodies.
+                var opaque = shader.DrawBucket == 0;
+
                 switch (hash)
                 {
                     case 0x61C0C8F9: //CityNormalMap
@@ -932,12 +937,10 @@ namespace CodeX.Games.MCLA.RSC5
                         break;
                     case 0xA6DD4FC1: //CityWindowLOD
                     case 0x816FF892: //CityWindowUpper
-                        ShaderInputs.SetFloat(0x4D52C5FF, 0.0f); //AlphaScale
-                        break;
-                    default:
-                        ShaderInputs.SetFloat(0x4D52C5FF, 1.0f); //AlphaScale
+                        opaque = true;
                         break;
                 }
+                ShaderInputs.SetFloat(0x4D52C5FF, opaque ? 0.0f : 1.0f); //AlphaScale
 
                 var bucket = shader.DrawBucket;
                 switch (bucket)

--- a/RSC5/Rsc5Drawable.cs
+++ b/RSC5/Rsc5Drawable.cs
@@ -771,6 +771,7 @@ namespace CodeX.Games.MCLA.RSC5
         public uint Unknown_3Ch { get; set; }
 
         public Rsc5Shader ShaderRef { get; set; }
+        public bool RoadMaterial { get; set; } //Albedo is composited from the control and decal maps
         public ushort ShaderID { get; set; } //Read-written by parent model
         public BoundingBox4 AABB { get; set; } //Read-written by parent model
 
@@ -1092,6 +1093,11 @@ namespace CodeX.Games.MCLA.RSC5
             }
         }
 
+        //Road materials. The diffuse map here is NOT albedo: the game's own pixel shader samples
+        //it as "DiffuseSampler.yx" and feeds those two channels into the specular tint and a
+        //luminance term only, while the decal map is sampled ".xyzw" and carries the markings.
+        //Blue is never read so it sits at zero and the green holds the detail, which is what made
+        //every road and sidewalk render green.
         private void SetupDecalGrimeShader(Rsc5Shader s)
         {
             SetCoreShader<BlendShader>(ShaderBucket.Solid);
@@ -1111,25 +1117,28 @@ namespace CodeX.Games.MCLA.RSC5
                     {
                         switch (parm.Hash)
                         {
-                            case 0xF1FE2B71: //diffusesampler
+                            case 0xF1FE2B71: //diffusesampler, the control map
                             case 0x2b5170fd: //texturesampler
                             case 0x3e19076b: //detailmapsampler
                             case 0x605fcc60: //distancemapsampler
-                                Textures[0] = tex;
-                                break;
-                            case 0xA79AEEC0: //decalsampler
                                 Textures[1] = tex;
                                 break;
-                            case 0xE3381C99: //grimesampler
+                            case 0xA79AEEC0: //decalsampler, the markings overlay
                                 Textures[2] = tex;
                                 break;
-                            case 0xFE553678: //puddlesampler
+                            case 0xE3381C99: //grimesampler
                                 Textures[3] = tex;
                                 break;
                         }
                     }
                 }
             }
+
+            //Neither map is an albedo on its own, so the pair gets composited into one - see
+            //Rsc5RoadMaterial. That can only happen once the textures have been resolved by the
+            //file manager, so it just gets flagged here.
+            RoadMaterial = true;
+            Textures[0] = Rsc5RoadMaterial.GetAlbedo(Textures[1], Textures[2]);
         }
 
         private void SetupGrassTerrainShader(Rsc5Shader s)

--- a/RSC5/Rsc5Flash.cs
+++ b/RSC5/Rsc5Flash.cs
@@ -1,0 +1,273 @@
+﻿using CodeX.Games.MCLA.RPF3;
+using EXP = System.ComponentModel.ExpandableObjectConverter;
+using TC = System.ComponentModel.TypeConverterAttribute;
+
+namespace CodeX.Games.MCLA.RSC5
+{
+    //Serialized Flash movie (.xsf, resource type 27). The root block holds the character
+    //table; every character shares a 12 byte header and the type byte at +8 selects the layout.
+    public enum Rsc5FlashObjectType : byte
+    {
+        Movie = 0,
+        Shape = 1,
+        Font = 2,
+        Unknown3 = 3,
+        Bitmap = 4,
+        Sprite = 5,
+        Button = 6,
+        Text = 7
+    }
+
+    [TC(typeof(EXP))]
+    public class Rsc5FlashMovie : Rsc5BlockBaseMap
+    {
+        public override ulong BlockLength => 64;
+        public override uint VFT { get; set; }
+        public byte ObjectType { get; set; } //0, followed by the packer's 'pad' filler
+        public uint ScenesPosition { get; set; } //Scene descriptors, first dword is the ARGB background colour
+        public ushort ScenesCount { get; set; }
+        public uint CharactersPosition { get; set; }
+        public ushort CharactersCount { get; set; } //Fixed 1793 slot table, most of it unused
+        public Rsc5FlashObject[] Characters { get; set; }
+        public float Width { get; set; } //Stage size in pixels, 1280x720 in most files
+        public float Height { get; set; }
+        public float FrameRate { get; set; } //8.8 fixed point
+        public ushort FrameCount { get; set; }
+        public uint ShapeCount { get; set; }
+        public uint ImportsPosition { get; set; } //Resolved at runtime, always zeroed in the file
+        public ushort ImportsCount { get; set; }
+
+        public override void Read(Rsc5DataReader reader)
+        {
+            base.Read(reader);
+            ObjectType = reader.ReadByte();
+            reader.ReadBytes(3); //'pad'
+
+            ScenesPosition = reader.ReadUInt32();
+            ScenesCount = reader.ReadUInt16();
+            reader.ReadUInt16(); //capacity
+            reader.ReadUInt32(); //always 0
+
+            CharactersPosition = reader.ReadUInt32();
+            CharactersCount = reader.ReadUInt16();
+            reader.ReadUInt16(); //capacity
+            reader.ReadUInt32(); //always 0
+
+            Width = reader.ReadSingle();
+            reader.ReadUInt32(); //always 0
+            Height = reader.ReadSingle();
+            FrameRate = reader.ReadUInt16() / 256.0f;
+            FrameCount = reader.ReadUInt16();
+            ShapeCount = reader.ReadUInt32();
+
+            ImportsPosition = reader.ReadUInt32();
+            ImportsCount = reader.ReadUInt16();
+
+            //The character table is a fixed 1793 slot array and only a fraction of it is filled in;
+            //the rest holds packer filler or stale pointers, so every slot is validated before it is
+            //followed. Rsc5PtrArr can't be used here - it would try to read the junk.
+            Characters = new Rsc5FlashObject[CharactersCount];
+            for (int i = 0; i < CharactersCount; i++)
+            {
+                reader.Position = CharactersPosition + (ulong)(i * 4);
+                var ptr = reader.ReadUInt32();
+                if (!Rsc5Flash.IsCharacter(reader, ptr)) continue;
+
+                try
+                {
+                    Characters[i] = reader.ReadBlock<Rsc5FlashObject>(ptr);
+                }
+                catch (Exception ex)
+                {
+                    Characters[i] = null; //A single bad character shouldn't take the whole movie down
+                    Core.Engine.Console.Write("Rsc5FlashMovie", $"character {i} failed: {ex.Message}");
+                }
+            }
+        }
+
+        public override void Write(Rsc5DataWriter writer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return $"Flash movie: {Width}x{Height}, {CharactersCount} characters, {FrameRate}fps";
+        }
+    }
+
+    [TC(typeof(EXP))]
+    public class Rsc5FlashObject : Rsc5BlockBaseMap
+    {
+        public override ulong BlockLength => 32;
+        public override uint VFT { get; set; }
+        public Rsc5FlashObjectType ObjectType { get; set; }
+
+        //Bitmap (type 4)
+        public Rsc5Texture Texture { get; set; }
+        public string ExternalTextureName { get; set; } //Set instead of Texture when the art lives in another pack
+        public ushort Width { get; set; }
+        public ushort Height { get; set; }
+
+        //Font (type 2)
+        public uint GlyphPagesPosition { get; set; }
+        public ushort GlyphPagesCount { get; set; }
+
+        //Text (type 7)
+        public uint TextColour { get; set; } //ARGB
+        public ushort FontIndex { get; set; }
+        public ushort TextHeight { get; set; } //Twips
+        public ushort GlyphCount { get; set; }
+
+        public override void Read(Rsc5DataReader reader)
+        {
+            base.Read(reader);
+            ObjectType = (Rsc5FlashObjectType)reader.ReadByte();
+            reader.ReadBytes(3); //'pad'
+
+            switch (ObjectType)
+            {
+                case Rsc5FlashObjectType.Bitmap:
+                    var texturePtr = reader.ReadUInt32();
+                    var namePtr = reader.ReadUInt32();
+                    Width = reader.ReadUInt16();
+                    Height = reader.ReadUInt16();
+
+                    //One of the two is set: the art is either packed into this movie or pulled
+                    //from another pack (shared.xtd) by file name.
+                    if (Rsc5Flash.IsInVirtualSegment(reader, texturePtr, 64))
+                    {
+                        Texture = reader.ReadBlock<Rsc5Texture>(texturePtr);
+                    }
+                    else if (Rsc5Flash.IsInVirtualSegment(reader, namePtr, 1))
+                    {
+                        var pos = reader.Position;
+                        reader.Position = namePtr;
+                        ExternalTextureName = reader.ReadString();
+                        reader.Position = pos;
+                    }
+                    break;
+                case Rsc5FlashObjectType.Font:
+                    GlyphPagesPosition = reader.ReadUInt32();
+                    GlyphPagesCount = reader.ReadUInt16();
+                    break;
+                case Rsc5FlashObjectType.Text:
+                    reader.ReadUInt32(); //glyph record pointer
+                    reader.ReadUInt32(); //placement pointer
+                    reader.ReadUInt32();
+                    TextColour = reader.ReadUInt32();
+                    FontIndex = reader.ReadUInt16();
+                    TextHeight = reader.ReadUInt16();
+                    reader.ReadBytes(16); //bounds
+                    GlyphCount = reader.ReadUInt16();
+                    break;
+            }
+        }
+
+        public override void Write(Rsc5DataWriter writer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return ObjectType.ToString();
+        }
+    }
+
+    public static class Rsc5Flash
+    {
+        public const uint FlashMovieVFT = 0x00554944;
+        public const uint VirtualBase = 0x50000000;
+
+        private static readonly uint[] KnownFormats = [2, 82, 83, 84, 134];
+
+        //Unset pointers hold the packer's 0xCDCDCDCD filler, and stale ones can point past the
+        //end of the segment, so every pointer is bounds checked before it is followed.
+        public static bool IsInVirtualSegment(Rsc5DataReader reader, uint pointer, int size)
+        {
+            if ((pointer & 0xF0000000) != VirtualBase) return false;
+            var offset = (int)(pointer & 0x0FFFFFFF);
+            return offset >= 0 && offset + size <= Math.Min(reader.VirtualSize, reader.Data.Length);
+        }
+
+        //Only slots that actually carry a character have a null block map at +4, a type byte in
+        //range at +8 and the packer's 'pad' filler in the three bytes behind it.
+        public static bool IsCharacter(Rsc5DataReader reader, uint pointer)
+        {
+            if ((pointer & 0xF0000000) != VirtualBase) return false;
+
+            var offset = (int)(pointer & 0x0FFFFFFF);
+            var data = reader.Data;
+            if (offset < 0 || offset + 32 > Math.Min(reader.VirtualSize, data.Length)) return false;
+
+            if (ReadUInt32(data, offset + 4) != 0) return false;
+            if (data[offset + 8] > (byte)Rsc5FlashObjectType.Text) return false;
+            return data[offset + 9] == 'p' && data[offset + 10] == 'a' && data[offset + 11] == 'd';
+        }
+
+        //Fonts reach their glyph atlas through structures we don't decode yet, so the textures
+        //are collected by sweeping the virtual segment for grcTexture blocks instead. A block is
+        //accepted only when its name pointer resolves to a .dds string and its D3D header carries
+        //a format we know - that matches the character table exactly on every file tested.
+        public static List<ulong> FindTextureBlocks(byte[] data, int virtualSize)
+        {
+            var result = new List<ulong>();
+            var limit = Math.Min(virtualSize, data.Length) - 0x40;
+
+            for (int offset = 0; offset <= limit; offset += 4)
+            {
+                if (!TryGetVirtualOffset(data, offset + 0x18, virtualSize, out var nameOffset)) continue;
+                if (!TryGetVirtualOffset(data, offset + 0x1C, virtualSize - 0x40, out var d3dOffset)) continue;
+                if (!EndsWithDds(data, nameOffset, virtualSize)) continue;
+
+                var width = ReadUInt16(data, offset + 0x20);
+                var height = ReadUInt16(data, offset + 0x22);
+                if (width == 0 || height == 0 || width > 4096 || height > 4096) continue;
+
+                var format = ReadUInt32(data, d3dOffset + 0x20) & 0xFF;
+                if (Array.IndexOf(KnownFormats, format) < 0) continue;
+
+                result.Add(VirtualBase | (uint)offset);
+            }
+            return result;
+        }
+
+        private static bool TryGetVirtualOffset(byte[] data, int at, int limit, out int offset)
+        {
+            offset = 0;
+            var ptr = ReadUInt32(data, at);
+            if ((ptr & 0xF0000000) != Rsc5Flash.VirtualBase) return false;
+            offset = (int)(ptr & 0x0FFFFFFF);
+            return offset >= 0 && offset < limit;
+        }
+
+        private static bool EndsWithDds(byte[] data, int offset, int limit)
+        {
+            for (int i = offset; i < limit && i < offset + 256; i++)
+            {
+                var b = data[i];
+                if (b == 0)
+                {
+                    return i >= offset + 4
+                        && data[i - 4] == '.'
+                        && (data[i - 3] | 0x20) == 'd'
+                        && (data[i - 2] | 0x20) == 'd'
+                        && (data[i - 1] | 0x20) == 's';
+                }
+                if (b < 0x20 || b > 0x7E) return false;
+            }
+            return false;
+        }
+
+        private static uint ReadUInt32(byte[] data, int offset)
+        {
+            return (uint)((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]);
+        }
+
+        private static ushort ReadUInt16(byte[] data, int offset)
+        {
+            return (ushort)((data[offset] << 8) | data[offset + 1]);
+        }
+    }
+}

--- a/RSC5/Rsc5ModelResource.cs
+++ b/RSC5/Rsc5ModelResource.cs
@@ -1,10 +1,17 @@
-﻿namespace CodeX.Games.MCLA.RSC5
+﻿using System.Linq;
+using CodeX.Core.Engine;
+
+namespace CodeX.Games.MCLA.RSC5
 {
     public class Rsc5ModelResource : Rsc5BlockBaseMap //Fragments seem to be constructed dynamically from model resources
     {
+        //VFTs are stored little-endian in the file, so they read back byte reversed.
+        //0x6DE5B900 = 0x00B9E56D, the plain model resource; 0xF8726100 = 0x006172F8, the "_set" package.
+        public const uint SetPackageVFT = 0xF8726100;
+
         public override ulong BlockLength => 60;
         public override uint VFT { get; set; } = 0x0057C350;
-        public Rsc5Ptr<Rsc5Drawable> Drawable { get; set; }
+        public Rsc5Ptr<Rsc5DrawableLod> DrawableLod { get; set; }
         public uint Unknown_Ch { get; set; } //Always 0?
         public uint Unknown_10h { get; set; } //Always 0?
         public Rsc5PtrArr<Rsc5StringA> Unknown_14h { get; set; }
@@ -16,28 +23,155 @@
         public int Unknown_34h { get; set; } //-1, 2
         public uint Unknown_38h { get; set; } //Always 0?
 
+        //Only set for the "_set" package, which carries complete drawables instead of a bare lod
+        public Rsc5Str Name { get; set; }
+        public Rsc5DrawableBase[] Drawables { get; private set; }
+
+        public Piece Drawable { get; private set; }
+        public string LoadError { get; private set; }
+
         public override void Read(Rsc5DataReader reader)
         {
             base.Read(reader);
-            Drawable = reader.ReadPtr<Rsc5Drawable>();
-            Unknown_Ch = reader.ReadUInt32();
-            Unknown_10h = reader.ReadUInt32();
-            Unknown_14h = reader.ReadPtrArr<Rsc5StringA>();
-            Unknown_1Ch = reader.ReadPtrArr<Rsc5BlockMap>();
-            SkeletonRef = reader.ReadPtr<Rsc5SkeletonData>();
-            Unknown_28h = reader.ReadPtr<Rsc5BlockMap>();
-            Unknown_2Ch = reader.ReadPtr<Rsc5BlockMap>();
-            Unknown_30h = reader.ReadPtr<Rsc5BlockMap>();
-            Unknown_34h = reader.ReadInt32();
-            Unknown_38h = reader.ReadUInt32();
-            Drawable.Item?.SetSkeleton(SkeletonRef.Item);
+
+            if (VFT == SetPackageVFT)
+            {
+                ReadSetPackage(reader);
+                return;
+            }
+
+            // Normal Model Resource
+            DrawableLod = reader.ReadPtr<Rsc5DrawableLod>(); // 0x08
+            Unknown_Ch = reader.ReadUInt32(); // 0x0C
+            var Unknown_10h = reader.ReadUInt32(); // 0x10
+            var Unknown_14h = reader.ReadUInt32(); // 0x14
+            var Unknown_18h = reader.ReadUInt32(); // 0x18
+            var Unknown_1Ch = reader.ReadPtrArr<Rsc5BlockMap>(); // 0x1C - 0x23
+            SkeletonRef = reader.ReadPtr<Rsc5SkeletonData>(); // 0x24 - 0x27
+            Unknown_28h = reader.ReadPtr<Rsc5BlockMap>(); // 0x28 - 0x2B
+            Unknown_2Ch = reader.ReadPtr<Rsc5BlockMap>(); // 0x2C - 0x2F
+            var Unknown_30h = reader.ReadPtr<Rsc5BlockMap>(); // 0x30 - 0x33
+            var Unknown_34h = reader.ReadInt32(); // 0x34 - 0x37
+            var Unknown_38h = reader.ReadUInt32(); // 0x38 - 0x3B
+            var Unknown_3Ch = reader.ReadPtr<Rsc5BlockMap>(); // 0x3C - 0x3F
+
+            try
+            {
+                var lod = DrawableLod.Item;
+                if (lod == null)
+                {
+                    LoadError = "no drawable lod";
+                    return;
+                }
+
+                lod.LodDist = 9999f;
+                var drawable = new Rsc5Drawable
+                {
+                    Lod = lod,
+                    Lods = [lod]
+                };
+                drawable.Name = System.IO.Path.GetFileNameWithoutExtension(reader.FileEntry?.Name);
+                drawable.SetSkeleton(SkeletonRef.Item);
+                drawable.UpdateAllModels();
+                drawable.AssignShaders();
+                drawable.UpdateBounds();
+
+                var center = (drawable.BoundingBox.Minimum + drawable.BoundingBox.Maximum) / 2;
+                var radius = System.Numerics.Vector3.Distance(center, drawable.BoundingBox.Maximum);
+                drawable.BoundingSphere = new CodeX.Core.Numerics.BoundingSphere(center, radius);
+                Drawable = drawable;
+            }
+            catch (System.Exception ex)
+            {
+                LoadError = ex.GetType().Name + ": " + ex.Message;
+            }
+        }
+
+        //Character and prop "_set" resources. The payload is one or more complete rmcDrawables
+        //(shader group, skeleton, bounds and the four lods), not the lod-only layout above. Some
+        //files hang a single drawable off the root, others reach a whole wardrobe of them through
+        //a container we don't decode, so the drawables are located by signature instead.
+        private void ReadSetPackage(Rsc5DataReader reader)
+        {
+            Name = reader.ReadStr(); //0x08
+            Unknown_Ch = reader.ReadUInt32(); //0x0C, u16 count + u16 capacity
+
+            var positions = FindDrawables(reader.Data, reader.VirtualSize);
+            var drawables = new List<Rsc5DrawableBase>();
+            var baseName = Name.Value ?? System.IO.Path.GetFileNameWithoutExtension(reader.FileEntry?.Name);
+
+            foreach (var position in positions)
+            {
+                try
+                {
+                    var drawable = reader.ReadBlock<Rsc5DrawableBase>(position);
+                    if (drawable?.AllModels == null || drawable.AllModels.Length == 0) continue;
+
+                    drawable.Name ??= (positions.Count > 1)
+                        ? baseName + "_" + drawables.Count.ToString("00")
+                        : baseName;
+                    drawables.Add(drawable);
+                }
+                catch
+                {
+                    //A broken drawable shouldn't cost us the rest of the package
+                }
+            }
+
+            Drawables = [.. drawables];
+            Drawable = drawables.FirstOrDefault();
+            if (Drawable == null)
+            {
+                LoadError = "no drawable";
+            }
+        }
+
+        //An rmcDrawable is recognised by its three bounding vectors: the packer leaves 0x7F800001
+        //in the w component of each. Together with a null block map and a resolvable shader group
+        //and lod that's enough to pick them out of the segment without a false positive.
+        private static List<ulong> FindDrawables(byte[] data, int virtualSize)
+        {
+            var result = new List<ulong>();
+            var limit = Math.Min(virtualSize, data.Length) - 0x80;
+
+            for (int offset = 0; offset <= limit; offset += 16)
+            {
+                if (ReadUInt32(data, offset + 0x04) != 0) continue;
+                if (ReadUInt32(data, offset + 0x1C) != 0x7F800001) continue;
+                if (ReadUInt32(data, offset + 0x2C) != 0x7F800001) continue;
+                if (ReadUInt32(data, offset + 0x3C) != 0x7F800001) continue;
+                if (!IsVirtual(ReadUInt32(data, offset + 0x08), virtualSize, false)) continue;
+
+                var lods = false;
+                for (int i = 0; i < 4; i++)
+                {
+                    if (!IsVirtual(ReadUInt32(data, offset + 0x40 + i * 4), virtualSize, true)) { lods = false; break; }
+                    lods |= ReadUInt32(data, offset + 0x40 + i * 4) != 0;
+                }
+                if (!lods) continue;
+
+                result.Add(0x50000000ul | (uint)offset);
+            }
+            return result;
+        }
+
+        private static bool IsVirtual(uint pointer, int virtualSize, bool allowNull)
+        {
+            if (pointer == 0) return allowNull;
+            if ((pointer & 0xF0000000) != 0x50000000) return false;
+            return (pointer & 0x0FFFFFFF) < (uint)virtualSize;
+        }
+
+        private static uint ReadUInt32(byte[] data, int offset)
+        {
+            return (uint)((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]);
         }
 
         public override void Write(Rsc5DataWriter writer)
         {
             base.Write(writer);
             writer.WritePtr(BlockMap);
-            writer.WritePtr(Drawable);
+            writer.WritePtr(DrawableLod);
             writer.WriteUInt32(Unknown_Ch);
             writer.WriteUInt32(Unknown_10h);
             writer.WritePtrArr(Unknown_14h);

--- a/RSC5/Rsc5RoadMaterial.cs
+++ b/RSC5/Rsc5RoadMaterial.cs
@@ -1,0 +1,93 @@
+﻿using CodeX.Core.Engine;
+using CodeX.Core.Utilities;
+using System.Collections.Concurrent;
+
+namespace CodeX.Games.MCLA.RSC5
+{
+    //Road and ground materials don't have a plain albedo map. The game's pixel shader builds the
+    //surface colour out of two textures:
+    //
+    //    r5.xw = DiffuseSampler(TEXCOORD0).yx   // control map: .r = luminance, .g = specular mask
+    //    r8    = DecalSampler(TEXCOORD1)        // markings atlas, its alpha is the mask
+    //    result = lerp(r5.w, r8.rgb, r8.a)      // grey base with the decal composited over it
+    //
+    //Blue is never read, which is why the control map looks green on its own - showing it raw is
+    //what turned every road and sidewalk green.
+    //
+    //The base tiles (TEXCOORD0 runs to 20 and beyond) while the decal atlas is placed once per
+    //surface (TEXCOORD1 stays inside 0..1), so the two cannot be baked together: doing that
+    //repeats the atlas and litters the pavement with manhole covers and lane arrows. Until the
+    //renderer can sample a second UV set, only the grey base is reconstructed.
+    public static class Rsc5RoadMaterial
+    {
+        private static readonly ConcurrentDictionary<Texture, Texture> Cache = new();
+
+        public static Texture GetAlbedo(Texture control, Texture decal)
+        {
+            if (control?.Data == null) return decal;
+            return Cache.GetOrAdd(control, key => Build(key, null) ?? key);
+        }
+
+        private static Texture Build(Texture control, Texture decal)
+        {
+            var basePixels = DDSIO.GetPixels(control, 0); //BGRA
+            if (basePixels == null) return null;
+
+            var w = control.Width;
+            var h = control.Height;
+            var outPixels = new byte[w * h * 4];
+
+            byte[] decalPixels = null;
+            int dw = 0, dh = 0;
+            if (decal?.Data != null)
+            {
+                decalPixels = DDSIO.GetPixels(decal, 0);
+                dw = decal.Width;
+                dh = decal.Height;
+                if (decalPixels == null || dw <= 0 || dh <= 0) decalPixels = null;
+            }
+
+            for (int y = 0; y < h; y++)
+            {
+                var row = y * w * 4;
+                var drow = decalPixels != null ? (y * dh / h) * dw * 4 : 0;
+                for (int x = 0; x < w; x++)
+                {
+                    var o = row + x * 4;
+                    if (o + 3 >= basePixels.Length) break;
+
+                    var grey = basePixels[o + 2]; //red channel carries the surface luminance
+                    byte r = grey, g = grey, b = grey;
+
+                    if (decalPixels != null)
+                    {
+                        var d = drow + (x * dw / w) * 4;
+                        if (d + 3 < decalPixels.Length)
+                        {
+                            var a = decalPixels[d + 3];
+                            if (a != 0)
+                            {
+                                b = Mix(b, decalPixels[d], a);
+                                g = Mix(g, decalPixels[d + 1], a);
+                                r = Mix(r, decalPixels[d + 2], a);
+                            }
+                        }
+                    }
+
+                    outPixels[o] = b;
+                    outPixels[o + 1] = g;
+                    outPixels[o + 2] = r;
+                    outPixels[o + 3] = 255;
+                }
+            }
+
+            var name = control.Name + (decal != null ? "+" + decal.Name : "");
+            return Texture.Create(name, (ushort)w, (ushort)h, TextureFormat.A8R8G8B8, outPixels, false, TextureSamplerPreset.AnisotropicWrap);
+        }
+
+        private static byte Mix(byte dst, byte src, byte alpha)
+        {
+            return (byte)((dst * (255 - alpha) + src * alpha) / 255);
+        }
+    }
+}

--- a/RSC5/Rsc5Texture.cs
+++ b/RSC5/Rsc5Texture.cs
@@ -151,6 +151,8 @@ namespace CodeX.Games.MCLA.RSC5
         public float ColorOfsG { get; set; } = 0.0f; //m_ColorOfsG
         public float ColorOfsB { get; set; } = 0.0f; //m_ColorOfsB
         public int Size { get; set; }
+        public uint D3DValue { get; set; } //grcTexture D3D header dword: format in 0..5, endianness in 6..7, base address above
+        public uint[] D3DHeader { get; set; }
 
         public override void Read(Rsc5DataReader reader)
         {
@@ -172,13 +174,16 @@ namespace CodeX.Games.MCLA.RSC5
 
             reader.Position = D3DBaseTexture.Item.FilePosition + 0x20;
             var d3dValue = reader.ReadInt32();
-            var virtualW = Rpf3Crypto.GetVirtualSize(Width);
-            var virtualH = Rpf3Crypto.GetVirtualSize(Height);
             reader.Position = (ulong)Rpf3Crypto.GetBaseAdressFromDirect3D(d3dValue, reader);
 
+            D3DValue = (uint)d3dValue;
+            var hp = reader.Position;
+            reader.Position = D3DBaseTexture.Item.FilePosition;
+            D3DHeader = reader.ReadUInt32Arr(16);
+            reader.Position = hp;
             Format = ConvertToEngineFormat((Rsc5TextureFormat)(d3dValue & byte.MaxValue));
-            Size = CalcDataSize(virtualW, virtualH);
-            Data = reader.ReadBytes(Size);
+            Size = Rpf3Crypto.GetTiledSurfaceSize(Width, Height, Format);
+            Data = reader.ReadBytesPadded(Size);
             Sampler = TextureSampler.Create(TextureSamplerFilter.Anisotropic, TextureAddressMode.Wrap);
             Data = Rpf3Crypto.UnswizzleXbox360Data(Data, Width, Height, Format);
             Size = Data.Length; //In case of virtual dimensions, get the actual texture size


### PR DESCRIPTION
> **Note:** that description was made by AI because i dont have too much skills to write PR descriptions, but the code isnt.

This adds support for several MCLA file types that couldn't be opened before, and fixes three rendering problems that came from misreading what the game actually stores in a texture.

Every change was checked against the whole `xarchive_cache.rpf`, and against the game's own shaders where the behaviour wasn't obvious from the data alone.

## New formats

### `.xsf` — Flash UI

These were routed to `XtdFile`, which found nothing, because an `.xsf` isn't a texture dictionary. It's a serialized Flash movie: a root block with the stage size, frame rate and a character table, where every character shares a 12 byte header and the type byte at `+8` selects the layout (shape, font, bitmap, sprite, button, static text).

The character table is a fixed 1793 slot array and most of it is unused, holding packer filler or stale pointers, so each slot is validated before being followed. Bitmap characters hold either an embedded `grcTexture` or the name of one in another pack; fonts reach their glyph atlas through structures that aren't decoded yet, so the leftovers are found by sweeping the virtual segment for texture blocks.

All 18 `.xsf` files load — `hud.xsf` gives 56 textures, `garage.xsf` 265.

![xsf files now work](https://raw.githubusercontent.com/mzzvxm/CodeX.Games.MCLA/pr-assets/xsf-files-now-work.png)

### `.xtp` and `.xtl` — vehicle, brake and wheel packages

`.xtp` was never routed anywhere, and `.xtl` only exposed the three maps hanging off the root, so these packages showed almost nothing.

Both extensions are the same format (resource type 83), `.xtp` simply being the higher resolution build. The textures live in a `grcTextureDictionary` that sits in the slot the shader group reads as its `pgBase` block map. That slot really is a block map in most files, so it's only followed when the target looks like a dictionary — null block map, and hash and texture arrays with the same non-zero count.

`.xtl` went from 318 textures to **2835**, `.xtp` from nothing to **3033**. The 30 wheel packages still coming up empty have no physical segment and no dictionary at all; they only reference textures from elsewhere.

![xtp files now work](https://raw.githubusercontent.com/mzzvxm/CodeX.Games.MCLA/pr-assets/xtp-files-now-work.png)

### `.xrsc` — character and prop `_set` packages

327 `.xrsc` files threw a `NullReferenceException`. They use a different root (`0x006172F8`) whose payload is a complete `rmcDrawable` — shader group, skeleton, bounds and the four lods — rather than the bare lod group the plain model resource points at, and the old special case read that pointer as a lod.

Which slot holds the drawable moves around between files, and one of them reaches a whole wardrobe through a container that isn't decoded yet, so the drawables are located by signature instead: the packer leaves `0x7F800001` in the `w` component of the three bounding vectors, which together with a null block map and a resolvable shader group and lod picks them out with no false positives.

Everything below the root is byte for byte the same as the resource type already handled — only the VFTs differ — so no new block classes were needed. **All 9360 `.xrsc` files now load.** Checked against `drv_fa_001_set`: 16 models, 6948 vertices, 96 bones, bounding box 1.70 m tall.

![driver now loads](https://raw.githubusercontent.com/mzzvxm/CodeX.Games.MCLA/pr-assets/driver-now-loads.png)

This commit also drops the debug logging that wrote to a hardcoded path on every single load and swallowed every exception; failures are reported through a `LoadError` field instead.

### `.xcc` — CarConfig

Not a resource at all: `CarConfig::Load` reads the file straight over the object and only patches the vtables back in, so the 8176 bytes are the in-memory class layout and the VFTs stored in the file are overwritten on load. They now open as XML.

Decoded so far: vehicle and config name, license plate and its style, the six upgrade levels, and the vinyl layer table — 288 slots of 20 bytes split across five surfaces, using the offsets and capacities from the game's own tables. Each layer gives its shape id, ARGB colour, scale, position and rotation.

The base of the layer array was pinned down using the fact that the game compacts layers towards the start of each surface, so the used slots have to be a prefix of the range: 0 violations across all 399 files, against 466 for the nearest alternative offset. 2394 layers in total.

### Loose `.dds`, and the plain text types

The `.dds` files sitting directly in the archive (`sky`, `vehicle/shared_font`, ...) only ever opened in the hex viewer — they're ordinary little endian DDS, not a RAGE resource, and just needed a pack to be wrapped in. All 82 load.

`.sharetex`, `.mcpowerup`, `.dcl`, `.skel` and `.odr` are readable text but had no entry, so they opened as hex too.

## Fixes

### Tiled surfaces were sized from the wrong dimensions

A tiled Xenos surface pads both its row pitch and its row count out to whole 32 block tiles, so a 512x180 DXT5 occupies 128x64 blocks, not 128x45. `GetVirtualSize` only bumped dimensions below 128 up to 128 — which happens to be right for every small texture, but reads too little for anything at or above 128 that isn't a multiple of it. The untiler then walked past the end of the buffer and threw, which is why none of the `.xtd` files under `resources/ui/textures/garage/dyntextures/rewardvehicles` could be opened.

Sizes now come from a tile aligned calculation, the untiler works in tile aligned block counts and trims back to the real dimensions, and a short read at the end of a segment is zero filled instead of throwing.

To confirm this changed nothing else, the 56 textures of `hud.xsf` were exported before and after — byte identical.

### Diffuse alpha isn't opacity

The alpha channel of an MCLA diffuse map is a specular/gloss mask. `drv_mp_a_01_d`, for instance, never reaches 255 and sits at 0 across the beard, eyebrows, lips and neck — feeding that to the core shader as opacity punched holes straight through the head and dropped the neck entirely.

The draw bucket is the reliable signal: the game declares 0 for solid and only uses 1 and 2 for materials that really blend. Across the 327 character packages that's 1595 solid shaders against 63 visor and 65 alpha ones. Solid materials now render with texture alpha disabled.

### Roads and sidewalks rendered bright green

Road materials have no plain albedo map. The game's pixel shader reads `DiffuseSampler.yx` for a specular mask and a luminance term, samples `DecalSampler` for the markings, and composites the two by the decal's own alpha:

```
r5.xw = DiffuseSampler(uv).yx
r8    = DecalSampler(uv)
result = lerp(r5.w, r8.rgb, r8.a)
```

Blue is never read, which is why the control map looks green on its own — `l_ho_cc_ground_cement_01` has a blue channel of exactly zero across the entire texture. The **red** channel of that same map is the surface itself, and it decodes to clean grey asphalt and concrete, so that's what's reconstructed as the albedo.

The two maps use different texture coordinate sets — the base tiles while the decal atlas is placed once per surface — so they can't be baked together. Doing that repeats the atlas and litters the pavement with manhole covers and lane arrows. Bringing the markings back needs a second UV set at draw time, which isn't something this change can do on its own.

Across `be_smb_03_north` all ten road albedos are now neutral grey instead of green.

## Testing

Every reader was run over the full `xarchive_cache.rpf` with no exceptions:

| type | loaded | empty |
|---|---|---|
| `.xsf` | 20 | 1 |
| `.xtd` | 1713 | 0 |
| `.xtl` | 106 | 2 |
| `.xtp` | 271 | 28 |
| `.dds` | 82 | 0 |
| `.xcc` | 343 | 0 |
| `.xrsc` | 9371 | 0 |
| `.xcs` | 439 | 0 |

The remaining empties are genuine — packages with no physical segment and nothing to show.
